### PR TITLE
Fix Python checksum script

### DIFF
--- a/pa01.py
+++ b/pa01.py
@@ -72,16 +72,18 @@ def main():
     with open(infile, 'rb') as f:
         raw = f.read()
 
-    # character count includes all characters, including newlines
-    char_count = len(raw)
+    word_bytes = size // 8
+    pad_len = (word_bytes - (len(raw) % word_bytes)) % word_bytes
+    padded = raw + b'X' * pad_len
 
-    # text for output removes newlines
-    text = raw.decode('ascii')
-    printable = text.replace('\n', '')
-    for i in range(0, len(printable), 80):
-        print(printable[i:i + 80])
+    text = padded.decode('ascii')
+
+    print()
+    for i in range(0, len(text), 80):
+        print(text[i:i + 80])
 
     checksum = compute_checksum(raw, size)
+    char_count = len(padded)
     print(f"{size:2d} bit checksum is {checksum:8x} for all {char_count:4d} chars")
 
 


### PR DESCRIPTION
## Summary
- fix checksum padding and output formatting
- ensure 80-character lines include padding characters
- match baseline test expectations

## Testing
- `bash basetest.sh pa01.py`
- `bash pa01test.sh pa01.py`

------
https://chatgpt.com/codex/tasks/task_e_68578d483644832ca0f29ff8ac7419a7